### PR TITLE
use standalone proptypes package

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,12 +30,15 @@
     "karma-sourcemap-loader": "^0.3.5",
     "karma-webpack": "^1.7.0",
     "node-libs-browser": "^0.5.2",
-    "react": "0.14.x || ^15.0.0",
-    "react-dom": "0.14.x || ^15.0.0",
+    "react": "^0.14.9 || ^15.3.0",
+    "react-dom": "^0.14.9 || ^15.3.0",
     "webpack": "^1.9.10",
     "webpack-dev-server": "^1.9.0"
   },
+  "dependencies": {
+    "prop-types": "^0.14.9 || ^15.3.0"
+  },
   "peerDependencies": {
-    "react": "0.14.x || ^15.0.0"
+    "react": "^0.14.9 || ^15.3.0"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 import matchParser from './match_parser';
 
@@ -64,9 +65,9 @@ function keyElements() {
 }
 
 AutoLinkText.propTypes = {
-  text: React.PropTypes.string,
-  maxLength: React.PropTypes.oneOfType([
-    React.PropTypes.number,
-    React.PropTypes.string
+  text: PropTypes.string,
+  maxLength: PropTypes.oneOfType([
+    PropTypes.number,
+    PropTypes.string
   ])
 };


### PR DESCRIPTION
Since React 15.5, I've been receiving console warnings about using 'proptypes' directly. Here is a patch to use the new standalone 'prop-types' package.