### PR TITLE
Remove old packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,9 +32,6 @@
     "webpack": "^1.9.10",
     "webpack-dev-server": "^1.9.0"
   },
-  "dependencies": {
-    "react-pure-render": "^1.0.2"
-  },
   "peerDependencies": {
     "react": "0.14.x || ^15.0.0"
   }

--- a/src/__tests__/index_test.js
+++ b/src/__tests__/index_test.js
@@ -3,15 +3,9 @@ import ReactDOMServer from 'react-dom/server';
 import ReactTestUtils from 'react-dom/test-utils';
 import AutoLinkText from '../index';
 
-const {renderIntoDocument, createRenderer} = ReactTestUtils;
+const { renderIntoDocument } = ReactTestUtils;
 
 describe('<AutoLinkText />', function() {
-  let renderer;
-
-  beforeEach(function() {
-    renderer = createRenderer();
-  });
-
   function renderText(text, props={}) {
     return ReactDOMServer.renderToStaticMarkup(
       <AutoLinkText text={text} {...props} />

--- a/src/index.js
+++ b/src/index.js
@@ -1,11 +1,8 @@
 import React from 'react';
-import shouldPureComponentUpdate from 'react-pure-render/function';
 
 import matchParser from './match_parser';
 
-export default class AutoLinkText extends React.Component {
-  shouldComponentUpdate = shouldPureComponentUpdate
-
+export default class AutoLinkText extends React.PureComponent {
   render() {
     const text = this.props.text || '';
     return (


### PR DESCRIPTION
* Use `PureComponent` instead of `react-pure-render`
* Remove dead code causing warning about shallow renderer