### PR TITLE
Add ability to pass additional props for links

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -15,7 +15,11 @@ export default class AutoLinkText extends PureComponent {
         );
       }
       elements.push(
-        React.createElement('a', { href: match.getAnchorHref() }, match.getAnchorText())
+        React.createElement(
+          'a',
+          Object.assign({}, { href: match.getAnchorHref() }, this.props.linkProps),
+          match.getAnchorText()
+        )
       );
       lastIndex = match.position.end;
     });
@@ -81,6 +85,7 @@ export default class AutoLinkText extends PureComponent {
 
 AutoLinkText.propTypes = {
   text: PropTypes.string,
+  linkProps: PropTypes.object,
   maxLength: PropTypes.oneOfType([
     PropTypes.number,
     PropTypes.string

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -131,4 +131,10 @@ describe('<AutoLinkText />', () => {
       ).toBe('<span><span>This message </span></span>');
     });
   });
+
+  it('should allow to pass additional props for links', () => {
+    expect(
+      renderText('http://opengov.com', { linkProps: { className: 'customClass', target: '_blank' } })
+    ).toBe('<span><a href="http://opengov.com" class="customClass" target="_blank">opengov.com</a></span>');
+  });
 });


### PR DESCRIPTION
For `target='_blank'`, `rel='nofollow'`, custom classes, etc