### PR TITLE
AnchorText now has word-break(<wrb>) inside so it can be wrapped nicely.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -14,11 +14,22 @@ export default class AutoLinkText extends PureComponent {
           React.createElement('span', {}, text.slice(lastIndex, match.position.start))
         );
       }
+
+      const paths = match.getAnchorText().split("\/");
+      const refinedPaths = paths.reduce((acc, val, idx) => {
+        if(idx !== 0) {
+          acc.push(React.createElement('wbr'));
+        }
+        acc.push(React.createElement('span', {}, `${val}${idx !== paths.length - 1 ? "\/" : "" }`));
+
+        return acc;
+      }, []);
+
       elements.push(
         React.createElement(
           'a',
           Object.assign({}, { href: match.getAnchorHref() }, this.props.linkProps),
-          match.getAnchorText()
+          refinedPaths
         )
       );
       lastIndex = match.position.end;


### PR DESCRIPTION
The rendered AutoLink text from ReactNative and the same rendered AutoLink text from my custom app-simulator from my website didn't have the same wrapping style. After applying the word break (<wbr>) after the **slash**, now they look the same. ReactNative seems that it's treating the URL like a breakable sentence that can be wrapped normally. If it wasn't so, as if it could've treated it like one really long word, it will be ugly and have an overflowing problem.

### On Website:
**Before:**
![image](https://user-images.githubusercontent.com/4941095/128861278-98b4e39d-ef33-4269-a6ea-489c2d1a6ca9.png)

**After:**
![image](https://user-images.githubusercontent.com/4941095/128861735-0a6ceca8-21ad-42f4-afff-455155b3a333.png)


### React Native
![image](https://user-images.githubusercontent.com/4941095/128865658-115bbe4b-e3eb-46b6-88ac-bcd0dfb3c36f.png)
